### PR TITLE
fix: sync Docker image with OpenCode release version

### DIFF
--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     outputs:
       needs_update: ${{ steps.compare.outputs.needs_update }}
       version: ${{ steps.release.outputs.version }}
@@ -28,20 +31,36 @@ jobs:
             const version = tag.startsWith('v') ? tag.slice(1) : tag;
             core.setOutput('version', version);
 
-      - name: Get current image versions
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get current image version
         id: current
         run: |
-          TAGS=$(gh api /users/pilinux/packages/container/opencode/versions 2>/dev/null | jq -r 'if type == "array" then .[].metadata.container.tags[] else empty end' | sort -V | tail -1 || echo "")
-          echo "current_version=$TAGS" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          read_image_version() {
+            docker run --rm "ghcr.io/pilinux/opencode:$1" opencode --version 2>/dev/null \
+              | sed -n 's/^v//; /^[0-9]\+\.[0-9]\+\.[0-9]\+$/p' \
+              | tail -1
+          }
+
+          RELEASE_VERSION="${{ steps.release.outputs.version }}"
+          CURRENT_LATEST_VERSION="$(read_image_version latest)"
+          CURRENT_RELEASE_VERSION="$(read_image_version "$RELEASE_VERSION")"
+
+          echo "current_latest_version=$CURRENT_LATEST_VERSION" >> $GITHUB_OUTPUT
+          echo "current_release_version=$CURRENT_RELEASE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Compare versions
         id: compare
         run: |
           RELEASE_VERSION="${{ steps.release.outputs.version }}"
-          CURRENT_VERSION="${{ steps.current.outputs.current_version }}"
-          if [ -z "$CURRENT_VERSION" ] || [ "$(printf '%s\n' "$RELEASE_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" != "$RELEASE_VERSION" ]; then
+          CURRENT_LATEST_VERSION="${{ steps.current.outputs.current_latest_version }}"
+          CURRENT_RELEASE_VERSION="${{ steps.current.outputs.current_release_version }}"
+          if [ "$CURRENT_LATEST_VERSION" != "$RELEASE_VERSION" ] || [ "$CURRENT_RELEASE_VERSION" != "$RELEASE_VERSION" ]; then
             echo "needs_update=true" >> $GITHUB_OUTPUT
           else
             echo "needs_update=false" >> $GITHUB_OUTPUT
@@ -93,6 +112,8 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          build-args: |
+            OPENCODE_VERSION=${{ needs.check.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/pilinux/opencode,push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 */4 * * *'  # Every 4 hours
   workflow_dispatch:  # Allow manual trigger
 
+concurrency:
+  group: update-docker-image
+  cancel-in-progress: false
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -47,23 +51,23 @@ jobs:
               | tail -1
           }
 
-          RELEASE_VERSION="${{ steps.release.outputs.version }}"
-          CURRENT_LATEST_VERSION="$(read_image_version latest)"
-          CURRENT_RELEASE_VERSION="$(read_image_version "$RELEASE_VERSION")"
+          TARGET_VERSION="${{ steps.release.outputs.version }}"
+          PUBLISHED_LATEST_VERSION="$(read_image_version latest)"
+          PUBLISHED_TARGET_VERSION="$(read_image_version "$TARGET_VERSION")"
 
-          echo "current_latest_version=$CURRENT_LATEST_VERSION" >> $GITHUB_OUTPUT
-          echo "current_release_version=$CURRENT_RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "published_latest_version=$PUBLISHED_LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "published_target_version=$PUBLISHED_TARGET_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Compare versions
         id: compare
         run: |
-          RELEASE_VERSION="${{ steps.release.outputs.version }}"
-          CURRENT_LATEST_VERSION="${{ steps.current.outputs.current_latest_version }}"
-          CURRENT_RELEASE_VERSION="${{ steps.current.outputs.current_release_version }}"
-          if [ "$CURRENT_LATEST_VERSION" != "$RELEASE_VERSION" ] || [ "$CURRENT_RELEASE_VERSION" != "$RELEASE_VERSION" ]; then
-            echo "needs_update=true" >> $GITHUB_OUTPUT
+          TARGET_VERSION="${{ steps.release.outputs.version }}"
+          PUBLISHED_LATEST_VERSION="${{ steps.current.outputs.published_latest_version }}"
+          PUBLISHED_TARGET_VERSION="${{ steps.current.outputs.published_target_version }}"
+          if [ "$PUBLISHED_LATEST_VERSION" != "$TARGET_VERSION" ] || [ "$PUBLISHED_TARGET_VERSION" != "$TARGET_VERSION" ]; then
+            echo "needs_update=true" >> "$GITHUB_OUTPUT"
           else
-            echo "needs_update=false" >> $GITHUB_OUTPUT
+            echo "needs_update=false" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -84,8 +88,8 @@ jobs:
         id: prepare
         run: |
           platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-          echo "platform_pair=${platform//\//-}" >> $GITHUB_OUTPUT
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          echo "platform_pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:24.13.1-bookworm
 
+ARG OPENCODE_VERSION=latest
+
 # set working directory
 WORKDIR /app
 
@@ -7,8 +9,13 @@ WORKDIR /app
 RUN uname -m
 
 # install opencode globally
-RUN npm i -g opencode-ai&& \
-  echo "Installed opencode version: $(opencode --version)"
+RUN npm i -g "opencode-ai@${OPENCODE_VERSION}" && \
+  installed_version="$(opencode --version)" && \
+  echo "Installed opencode version: ${installed_version}" && \
+  if [ "${OPENCODE_VERSION}" != "latest" ] && [ "${installed_version}" != "${OPENCODE_VERSION}" ]; then \
+    echo "Expected opencode version ${OPENCODE_VERSION}, got ${installed_version}" >&2; \
+    exit 1; \
+  fi
 
 # non-root user (recommended)
 RUN adduser --disabled-password opencode

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN uname -m
 
 # install opencode globally
 RUN npm i -g "opencode-ai@${OPENCODE_VERSION}" && \
-  installed_version="$(opencode --version)" && \
+  installed_version_raw="$(opencode --version)" && \
+  installed_version="${installed_version_raw#v}" && \
   echo "Installed opencode version: ${installed_version}" && \
   if [ "${OPENCODE_VERSION}" != "latest" ] && [ "${installed_version}" != "${OPENCODE_VERSION}" ]; then \
     echo "Expected opencode version ${OPENCODE_VERSION}, got ${installed_version}" >&2; \


### PR DESCRIPTION
- Pass the latest release version into Docker builds
- Install opencode-ai at the requested version
- Verify the installed CLI version during image build
- Compare runtime image versions instead of package tag names